### PR TITLE
Fix search modal accessibility and button style

### DIFF
--- a/js/search-ui.js
+++ b/js/search-ui.js
@@ -76,6 +76,7 @@ class SearchUI {
   showSearchModal() {
     const modal = document.getElementById("searchModal");
     modal.style.display = "block";
+    modal.setAttribute("aria-hidden", "false");
     document.getElementById("searchInput").value = "";
     this.clearSearch();
     setTimeout(() => {

--- a/js/transaction-ui.js
+++ b/js/transaction-ui.js
@@ -459,8 +459,19 @@ class TransactionUI {
 
   
   closeModals() {
-    document.getElementById("transactionModal").style.display = "none";
-    document.getElementById("searchModal").style.display = "none";
+    const transactionModal = document.getElementById("transactionModal");
+    const searchModal = document.getElementById("searchModal");
+
+    const activeEl = document.activeElement;
+    if (
+      activeEl &&
+      (transactionModal.contains(activeEl) || searchModal.contains(activeEl))
+    ) {
+      activeEl.blur();
+    }
+
+    transactionModal.style.display = "none";
+    searchModal.style.display = "none";
     document.getElementById("transactionAmount").value = "";
     document.getElementById("transactionDescription").value = "";
     document.getElementById("transactionRecurrence").value = "once";

--- a/styles.css
+++ b/styles.css
@@ -361,11 +361,6 @@ body {
 }
 
 #searchButton {
-  padding: 8px 16px;
-  background-color: #f1f1f1;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
   margin-top: 10px;
 }
 


### PR DESCRIPTION
## Summary
- remove custom gray styling from the search button so it uses primary color
- open the search modal with `aria-hidden="false"`
- blur active element before hiding modals to avoid accessibility warning

## Testing
- `npm test` *(fails: could not find package.json)*