### PR TITLE
Refactor cleanUpHtmlArtifacts to iterate backward

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -50,13 +50,12 @@ class CashflowApp {
   
   cleanUpHtmlArtifacts() {
     const bodyChildren = document.body.childNodes;
-    for (let i = 0; i < bodyChildren.length; i++) {
+    for (let i = bodyChildren.length - 1; i >= 0; i--) {
       const node = bodyChildren[i];
       if (node.nodeType === Node.TEXT_NODE && 
           (node.textContent.includes("<div") || 
            node.textContent.includes("modal-content"))) {
         document.body.removeChild(node);
-        i--;
       }
     }
   }


### PR DESCRIPTION
This commit refactors the `cleanUpHtmlArtifacts` method in `js/app.js` to iterate backward through `document.body.childNodes`. This prevents potential issues that can arise when modifying a collection (removing nodes) while iterating over it in a forward direction. The change ensures more robust and predictable behavior during the cleanup of HTML artifacts.