### PR TITLE
Replace browser alerts/confirms/prompts with app modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,46 @@
       </div>
     </div>
 
+    <div
+      id="appModal"
+      class="modal"
+      role="dialog"
+      aria-labelledby="appModalTitle"
+      aria-modal="true"
+      aria-hidden="true"
+    >
+      <div class="modal-content app-modal-content">
+        <button
+          id="appModalClose"
+          class="close"
+          aria-label="Close"
+          type="button"
+        >
+          &times;
+        </button>
+        <h3 id="appModalTitle"></h3>
+        <div class="app-modal-body">
+          <p id="appModalMessage" class="app-modal-message"></p>
+          <label class="app-modal-input-wrapper" for="appModalInput">
+            <span id="appModalInputLabel" class="app-modal-input-label"></span>
+            <input id="appModalInput" class="app-modal-input" type="text" />
+          </label>
+        </div>
+        <div class="app-modal-actions">
+          <button
+            id="appModalCancel"
+            class="secondary-button"
+            type="button"
+          >
+            Cancel
+          </button>
+          <button id="appModalConfirm" class="primary-button" type="button">
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+
     <script src="js/utils.js"></script>
 
     <script src="js/transaction-store.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -168,22 +168,26 @@ class CashflowApp {
   }
 
   
-  resetData() {
+  async resetData() {
     try {
       this.cloudSync.cancelPendingCloudSave();
 
-      if (
-        confirm(
-          "Are you sure you want to reset all data? This will also clear your cloud sync credentials."
-        )
-      ) {
-        this.store.resetData();
-        this.cloudSync.clearCloudCredentials();
-        this.calculationService.invalidateCache();
-        this.updateUI();
-        
-        Utils.showNotification("All data has been reset.");
+      const shouldReset = await Utils.showModalConfirm(
+        "Are you sure you want to reset all data? This will also clear your cloud sync credentials.",
+        "Reset Data",
+        { confirmText: "Reset", cancelText: "Cancel" }
+      );
+
+      if (!shouldReset) {
+        return;
       }
+
+      this.store.resetData();
+      this.cloudSync.clearCloudCredentials();
+      this.calculationService.invalidateCache();
+      this.updateUI();
+      
+      Utils.showNotification("All data has been reset.");
     } catch (error) {
       console.error("Error resetting data:", error);
       Utils.showNotification("Failed to reset data: " + error.message, "error");
@@ -192,7 +196,9 @@ class CashflowApp {
 }
 document.addEventListener("DOMContentLoaded", () => {
   window.pinProtection = new PinProtection();
-  pinProtection.promptUnlock(() => {
-    window.app = new CashflowApp(pinProtection);
+  pinProtection.promptUnlock().then((unlocked) => {
+    if (unlocked) {
+      window.app = new CashflowApp(pinProtection);
+    }
   });
 });

--- a/js/cloud-sync.js
+++ b/js/cloud-sync.js
@@ -216,7 +216,7 @@ class CloudSync {
         reject(new Error("Credentials entry cancelled"));
       };
 
-      saveBtn.onclick = () => {
+      saveBtn.onclick = async () => {
         const token = tokenInput.value.trim();
         const gistId = gistInput.value.trim();
         this.autoSyncEnabled = autoSyncCheck.checked;
@@ -227,7 +227,10 @@ class CloudSync {
         }
 
         if (!token) {
-          alert("Please enter a GitHub token");
+          await Utils.showModalAlert(
+            "Please enter a GitHub token",
+            "Missing Token"
+          );
           return;
         }
 
@@ -395,7 +398,11 @@ class CloudSync {
           throw new Error("Invalid GitHub token or missing gist permissions");
         }
         if (response.status === 404) {
-          const createNew = confirm("Gist not found. Would you like to create a new one?");
+          const createNew = await Utils.showModalConfirm(
+            "Gist not found. Would you like to create a new one?",
+            "Gist Not Found",
+            { confirmText: "Create New", cancelText: "Cancel" }
+          );
           if (createNew) {
             Utils.showNotification("Creating new Gist...");
             const newGistId = await this.createNewGist(token, data);

--- a/js/debt-snowball.js
+++ b/js/debt-snowball.js
@@ -256,13 +256,18 @@ class DebtSnowballUI {
     this.showDebtForm(debt);
   }
 
-  deleteDebt(debtId) {
+  async deleteDebt(debtId) {
     const debt = this.store.getDebts().find((d) => d.id === debtId);
     if (!debt) {
       Utils.showNotification("Debt not found", "error");
       return;
     }
-    if (!confirm(`Delete debt "${debt.name}"?`)) {
+    const shouldDelete = await Utils.showModalConfirm(
+      `Delete debt "${debt.name}"?`,
+      "Delete Debt",
+      { confirmText: "Delete", cancelText: "Cancel" }
+    );
+    if (!shouldDelete) {
       return;
     }
     if (debt.minRecurringId) {

--- a/js/pin-protection.js
+++ b/js/pin-protection.js
@@ -55,51 +55,82 @@ class PinProtection {
     }
   }
 
-  promptUnlock(callback) {
+  async promptUnlock() {
     if (!this.isPinSet()) {
-      callback();
-      return;
+      return true;
     }
-    let pin = prompt("Enter PIN to unlock:");
-    if (pin === null) return;
+    const pin = await Utils.showModalPrompt("Enter PIN to unlock:", "Unlock", {
+      inputLabel: "PIN",
+      inputType: "password",
+      confirmText: "Unlock",
+      cancelText: "Cancel",
+    });
+    if (pin === null) return false;
     if (this.verifyPin(pin)) {
       this.currentPin = pin;
-      callback();
-    } else {
-      alert("Incorrect PIN");
-      this.promptUnlock(callback);
+      return true;
     }
+    await Utils.showModalAlert("Incorrect PIN", "Unlock Failed");
+    return this.promptUnlock();
   }
 
-  promptChangePin(store) {
+  async promptChangePin(store) {
     let newPin;
     if (this.isPinSet()) {
-      const oldPin = prompt("Enter current PIN:");
+      const oldPin = await Utils.showModalPrompt(
+        "Enter current PIN:",
+        "Change PIN",
+        {
+          inputLabel: "Current PIN",
+          inputType: "password",
+          confirmText: "Continue",
+        }
+      );
       if (oldPin === null) return;
       if (!this.verifyPin(oldPin)) {
-        alert("Incorrect PIN");
+        await Utils.showModalAlert("Incorrect PIN", "Change PIN");
         return;
       }
-      newPin = prompt("Enter new PIN (leave blank to disable):");
+      newPin = await Utils.showModalPrompt(
+        "Enter new PIN (leave blank to disable):",
+        "Change PIN",
+        {
+          inputLabel: "New PIN",
+          inputType: "password",
+          confirmText: "Continue",
+        }
+      );
       if (newPin === null) return;
       if (newPin === "") {
         this.clearPin();
         store.saveData(false);
-        alert("PIN disabled");
+        await Utils.showModalAlert("PIN disabled", "Change PIN");
         return;
       }
     } else {
-      newPin = prompt("Set a new PIN:");
+      newPin = await Utils.showModalPrompt("Set a new PIN:", "Set PIN", {
+        inputLabel: "New PIN",
+        inputType: "password",
+        confirmText: "Set PIN",
+      });
       if (newPin === null || newPin === "") return;
     }
-    const confirmPin = prompt("Confirm PIN:");
+    const confirmPin = await Utils.showModalPrompt(
+      "Confirm PIN:",
+      "Confirm PIN",
+      {
+        inputLabel: "Confirm PIN",
+        inputType: "password",
+        confirmText: "Save PIN",
+      }
+    );
     if (confirmPin === null || confirmPin !== newPin) {
-      alert("PINs do not match");
+      await Utils.showModalAlert("PINs do not match", "Confirm PIN");
       return;
     }
     this.setPin(newPin);
     store.saveData(false);
-    alert("PIN updated");
+    await Utils.showModalAlert("PIN updated", "Change PIN");
   }
 }
 

--- a/js/transaction-ui.js
+++ b/js/transaction-ui.js
@@ -812,7 +812,7 @@ class TransactionUI {
     try {
       const modal = document.getElementById("transactionModal");
       if (!modal) {
-        alert("Transaction modal not found!");
+        Utils.showModalAlert("Transaction modal not found!", "Missing Modal");
         return;
       }
       const modalDate = document.getElementById("modalDate");
@@ -850,7 +850,10 @@ class TransactionUI {
       }
     } catch (error) {
       console.error("Fallback modal opening failed:", error);
-      alert("Could not open transaction details. Please check the console for errors.");
+      Utils.showModalAlert(
+        "Could not open transaction details. Please check the console for errors.",
+        "Transaction Details"
+      );
     }
   }
 
@@ -934,7 +937,7 @@ class TransactionUI {
   }
 
   
-  deleteTransaction(date, index) {
+  async deleteTransaction(date, index) {
     const transactions = this.store.getTransactions();
     if (!transactions[date] || !transactions[date][index]) {
       console.error(`Transaction not found: date=${date}, index=${index}`);
@@ -945,19 +948,26 @@ class TransactionUI {
     const transaction = transactions[date][index];
 
     if (transaction.recurringId) {
-      const confirmDelete = confirm(
-        "Do you want to delete just this occurrence or all future occurrences?\n\n" +
-          "OK = Delete all future occurrences\n" +
-          "Cancel = Delete only this occurrence"
+      const confirmDelete = await Utils.showModalConfirm(
+        "Do you want to delete just this occurrence or all future occurrences?",
+        "Delete Recurring Transaction",
+        {
+          confirmText: "Delete All Future",
+          cancelText: "Delete Only This",
+        }
       );
 
       this.recurringManager.deleteTransaction(date, index, confirmDelete);
     } else {
-      if (confirm("Are you sure you want to delete this transaction?")) {
-        this.store.deleteTransaction(date, index);
-      } else {
+      const shouldDelete = await Utils.showModalConfirm(
+        "Are you sure you want to delete this transaction?",
+        "Delete Transaction",
+        { confirmText: "Delete", cancelText: "Cancel" }
+      );
+      if (!shouldDelete) {
         return;
       }
+      this.store.deleteTransaction(date, index);
     }
 
     this.showTransactionDetails(date);

--- a/js/utils.js
+++ b/js/utils.js
@@ -46,4 +46,172 @@ const Utils = {
       setTimeout(() => toast.remove(), 300);
     }, 3000);
   },
+
+  getAppModalElements: function () {
+    const modal = document.getElementById("appModal");
+    if (!modal) {
+      console.warn("App modal not found in the DOM.");
+      return null;
+    }
+
+    return {
+      modal,
+      title: document.getElementById("appModalTitle"),
+      message: document.getElementById("appModalMessage"),
+      input: document.getElementById("appModalInput"),
+      inputLabel: document.getElementById("appModalInputLabel"),
+      inputWrapper: modal.querySelector(".app-modal-input-wrapper"),
+      confirmButton: document.getElementById("appModalConfirm"),
+      cancelButton: document.getElementById("appModalCancel"),
+      closeButton: document.getElementById("appModalClose"),
+    };
+  },
+
+  showModalDialog: function ({
+    title = "Notice",
+    message = "",
+    confirmText = "OK",
+    cancelText = "Cancel",
+    showCancel = false,
+    showInput = false,
+    inputLabel = "",
+    inputValue = "",
+    inputType = "text",
+  } = {}) {
+    const elements = this.getAppModalElements();
+    if (!elements) {
+      if (showInput) {
+        return Promise.resolve(null);
+      }
+      if (showCancel) {
+        return Promise.resolve(false);
+      }
+      return Promise.resolve();
+    }
+
+    const {
+      modal,
+      title: titleEl,
+      message: messageEl,
+      input,
+      inputLabel: inputLabelEl,
+      inputWrapper,
+      confirmButton,
+      cancelButton,
+      closeButton,
+    } = elements;
+
+    titleEl.textContent = title;
+    messageEl.textContent = message;
+    confirmButton.textContent = confirmText;
+    cancelButton.textContent = cancelText;
+    cancelButton.style.display = showCancel ? "inline-flex" : "none";
+
+    if (showInput) {
+      inputWrapper.classList.add("is-visible");
+      input.type = inputType;
+      input.value = inputValue;
+      inputLabelEl.textContent = inputLabel;
+    } else {
+      inputWrapper.classList.remove("is-visible");
+      input.value = "";
+      inputLabelEl.textContent = "";
+    }
+
+    modal.style.display = "block";
+    modal.setAttribute("aria-hidden", "false");
+
+    const previousActiveElement = document.activeElement;
+
+    return new Promise((resolve) => {
+      const closeModal = (result) => {
+        modal.style.display = "none";
+        modal.setAttribute("aria-hidden", "true");
+        confirmButton.removeEventListener("click", handleConfirm);
+        cancelButton.removeEventListener("click", handleCancel);
+        closeButton.removeEventListener("click", handleCancel);
+        modal.removeEventListener("click", handleBackdrop);
+        modal.removeEventListener("keydown", handleKeydown);
+        if (previousActiveElement && previousActiveElement.focus) {
+          previousActiveElement.focus();
+        }
+        resolve(result);
+      };
+
+      const handleConfirm = () => {
+        if (showInput) {
+          closeModal(input.value);
+        } else {
+          closeModal(true);
+        }
+      };
+
+      const handleCancel = () => {
+        if (showInput) {
+          closeModal(null);
+        } else {
+          closeModal(false);
+        }
+      };
+
+      const handleBackdrop = (event) => {
+        if (event.target === modal) {
+          handleCancel();
+        }
+      };
+
+      const handleKeydown = (event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          handleCancel();
+        }
+        if (event.key === "Enter" && showInput) {
+          event.preventDefault();
+          handleConfirm();
+        }
+      };
+
+      confirmButton.addEventListener("click", handleConfirm);
+      cancelButton.addEventListener("click", handleCancel);
+      closeButton.addEventListener("click", handleCancel);
+      modal.addEventListener("click", handleBackdrop);
+      modal.addEventListener("keydown", handleKeydown);
+
+      setTimeout(() => {
+        if (showInput) {
+          input.focus();
+        } else {
+          confirmButton.focus();
+        }
+      }, 50);
+    });
+  },
+
+  showModalAlert: function (message, title = "Notice") {
+    return this.showModalDialog({ title, message, showCancel: false });
+  },
+
+  showModalConfirm: function (message, title = "Confirm", options = {}) {
+    return this.showModalDialog({
+      title,
+      message,
+      showCancel: true,
+      confirmText: options.confirmText || "OK",
+      cancelText: options.cancelText || "Cancel",
+    });
+  },
+
+  showModalPrompt: function (message, title = "Prompt", options = {}) {
+    return this.showModalDialog({
+      title,
+      message,
+      showCancel: true,
+      showInput: true,
+      inputLabel: options.inputLabel || "",
+      inputValue: options.inputValue || "",
+      inputType: options.inputType || "text",
+      confirmText: options.confirmText || "OK",
+      cancelText: options.cancelText || "Cancel",
+    });
+  },
 };

--- a/styles.css
+++ b/styles.css
@@ -195,6 +195,49 @@ body {
   overflow-y: auto;
 }
 
+.app-modal-content {
+  max-width: 420px;
+}
+
+.app-modal-body {
+  margin-top: 12px;
+}
+
+.app-modal-message {
+  margin: 0;
+}
+
+.app-modal-input-wrapper {
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 12px;
+  font-weight: 600;
+}
+
+.app-modal-input-wrapper.is-visible {
+  display: flex;
+}
+
+.app-modal-input {
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  font-size: 1rem;
+  padding: 10px;
+}
+
+.app-modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.app-modal-actions button {
+  min-width: 110px;
+}
+
 .close {
   color: #aaa;
   float: right;


### PR DESCRIPTION
### Motivation
- Replace native `alert`, `confirm`, and `prompt` dialogs with an in-app modal to provide a consistent, accessible UI and avoid blocking browser dialogs.
- Provide reusable helpers for alerts, confirms, and prompts so various flows can use the same modal UX.

### Description
- Add an `#appModal` markup block to `index.html` and associated styles in `styles.css` to render a reusable application modal dialog.
- Implement modal helpers in `Utils` (`getAppModalElements`, `showModalDialog`, `showModalAlert`, `showModalConfirm`, `showModalPrompt`) in `js/utils.js` for programmatic use.
- Migrate flows that used native dialogs to the modal helpers, including PIN unlock/change (`js/pin-protection.js`), cloud sync credential prompts and Gist-not-found confirmation (`js/cloud-sync.js`), app reset (`js/app.js`), debt deletion (`js/debt-snowball.js`), and transaction deletion/fallback (`js/transaction-ui.js`).
- Update initialization to await the asynchronous PIN unlock and adjust related focus/behavior to maintain UX consistency.

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright smoke script that invoked `Utils.showModalAlert(...)` and captured a screenshot of the modal, which succeeded and produced `artifacts/app-modal.png`.
- No unit tests were added; no other automated test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6961363b28a48327a1da5e3b361e83c9)