### PR TITLE
Fix recurring delete modal dismissal

### DIFF
--- a/js/transaction-ui.js
+++ b/js/transaction-ui.js
@@ -954,8 +954,13 @@ class TransactionUI {
         {
           confirmText: "Delete All Future",
           cancelText: "Delete Only This",
+          closeReturnsNull: true,
         }
       );
+
+      if (confirmDelete === null) {
+        return;
+      }
 
       this.recurringManager.deleteTransaction(date, index, confirmDelete);
     } else {

--- a/js/utils.js
+++ b/js/utils.js
@@ -77,6 +77,7 @@ const Utils = {
     inputLabel = "",
     inputValue = "",
     inputType = "text",
+    closeReturnsNull = false,
   } = {}) {
     const elements = this.getAppModalElements();
     if (!elements) {
@@ -154,16 +155,24 @@ const Utils = {
         }
       };
 
+      const handleClose = () => {
+        if (closeReturnsNull) {
+          closeModal(null);
+        } else {
+          handleCancel();
+        }
+      };
+
       const handleBackdrop = (event) => {
         if (event.target === modal) {
-          handleCancel();
+          handleClose();
         }
       };
 
       const handleKeydown = (event) => {
         if (event.key === "Escape") {
           event.preventDefault();
-          handleCancel();
+          handleClose();
         }
         if (event.key === "Enter" && showInput) {
           event.preventDefault();
@@ -173,7 +182,7 @@ const Utils = {
 
       confirmButton.addEventListener("click", handleConfirm);
       cancelButton.addEventListener("click", handleCancel);
-      closeButton.addEventListener("click", handleCancel);
+      closeButton.addEventListener("click", handleClose);
       modal.addEventListener("click", handleBackdrop);
       modal.addEventListener("keydown", handleKeydown);
 
@@ -198,6 +207,7 @@ const Utils = {
       showCancel: true,
       confirmText: options.confirmText || "OK",
       cancelText: options.cancelText || "Cancel",
+      closeReturnsNull: options.closeReturnsNull === true,
     });
   },
 


### PR DESCRIPTION
### Motivation
- Clicking the modal close (X), backdrop, or pressing Escape while answering the recurring-delete prompt caused the code to treat the dismissal as a concrete `cancel` value and proceed, which resulted in skipping/deleting the occurrence unexpectedly.  
- The intent is to treat a user dismissing the dialog (X/backdrop/Escape) as a no-op for the recurring-delete flow so accidental dismissals do not modify data.  

### Description
- Added an optional `closeReturnsNull` parameter to `Utils.showModalDialog` and propagated it to `showModalConfirm` via `closeReturnsNull: options.closeReturnsNull === true`.  
- Implemented a `handleClose` helper that returns `null` when `closeReturnsNull` is true and wired it to the close button, backdrop click, and Escape key handling.  
- Updated `deleteTransaction` in `js/transaction-ui.js` to call `showModalConfirm` with `closeReturnsNull: true` for recurring deletes and to abort when the result is `null`.  

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696143db7320832780d1e191d56d2560)